### PR TITLE
feat: Implement deal creation form

### DIFF
--- a/app/deals/new/page.tsx
+++ b/app/deals/new/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { clientQueries } from "@/lib/database/queries";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useSellers } from "@/hooks/use-sellers";
+import { useBuyers } from "@/hooks/use-buyers";
+import { useInvestors } from "@/hooks/use-investors";
+import { useToast } from "@/components/ui/use-toast";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const formSchema = z.object({
+  seller_id: z.string().uuid(),
+  buyer_id: z.string().uuid(),
+  investor_id: z.string().uuid().optional(),
+  status: z.enum(["new", "quoted", "contracted", "closed"]),
+});
+
+export default function NewDealPage() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const { sellers, loading: sellersLoading } = useSellers();
+  const { buyers, loading: buyersLoading } = useBuyers();
+  const { investors, loading: investorsLoading } = useInvestors();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      status: "new",
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    try {
+      // This is a placeholder for the actual user and company ID
+      // In a real app, you would get this from the user's session
+      const currentUser = await clientQueries.getCurrentUser();
+      if (!currentUser) {
+        throw new Error("User not found");
+      }
+
+      await clientQueries.createDeal({
+        ...values,
+        company_id: currentUser.company_id,
+        created_by: currentUser.id,
+      });
+      toast({
+        title: "Success",
+        description: "Deal created successfully.",
+      });
+      router.push("/deals");
+    } catch (error) {
+      console.error("Error creating deal:", error);
+      toast({
+        title: "Error",
+        description: "Failed to create deal. Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const isLoading = sellersLoading || buyersLoading || investorsLoading;
+
+  return (
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+      <div className="flex items-center justify-between space-y-2">
+        <h2 className="text-3xl font-bold tracking-tight">Create New Deal</h2>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Deal Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-1/4" />
+            </div>
+          ) : (
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="seller_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Seller</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a seller" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {sellers.map((seller) => (
+                            <SelectItem key={seller.id} value={seller.id}>
+                              {seller.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="buyer_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Buyer</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a buyer" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {buyers.map((buyer) => (
+                            <SelectItem key={buyer.id} value={buyer.id}>
+                              {buyer.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="investor_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Investor (Optional)</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select an investor" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {investors.map((investor) => (
+                            <SelectItem key={investor.id} value={investor.id}>
+                              {investor.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="status"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Status</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a status" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="new">New</SelectItem>
+                          <SelectItem value="quoted">Quoted</SelectItem>
+                          <SelectItem value="contracted">Contracted</SelectItem>
+                          <SelectItem value="closed">Closed</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit" disabled={form.formState.isSubmitting}>
+                  {form.formState.isSubmitting ? "Creating..." : "Create Deal"}
+                </Button>
+              </form>
+            </Form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/hooks/use-buyers.ts
+++ b/hooks/use-buyers.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { clientQueries } from "@/lib/database/queries";
+import type { Buyer as BuyerType } from "@/types/database";
+
+export type Buyer = BuyerType & {
+  created_by_user: { name: string } | null;
+};
+
+export const useBuyers = () => {
+  const [buyers, setBuyers] = useState<Buyer[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchBuyers = async () => {
+      try {
+        setLoading(true);
+        const data = await clientQueries.getBuyers();
+        setBuyers(data as Buyer[]);
+      } catch (error) {
+        console.error("Error fetching buyers:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBuyers();
+  }, []);
+
+  return { buyers, loading };
+};

--- a/hooks/use-investors.ts
+++ b/hooks/use-investors.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { clientQueries } from "@/lib/database/queries";
+import type { Investor as InvestorType } from "@/types/database";
+
+export type Investor = InvestorType & {
+  created_by_user: { name: string } | null;
+};
+
+export const useInvestors = () => {
+  const [investors, setInvestors] = useState<Investor[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchInvestors = async () => {
+      try {
+        setLoading(true);
+        const data = await clientQueries.getInvestors();
+        setInvestors(data as Investor[]);
+      } catch (error) {
+        console.error("Error fetching investors:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchInvestors();
+  }, []);
+
+  return { investors, loading };
+};

--- a/hooks/use-sellers.ts
+++ b/hooks/use-sellers.ts
@@ -1,25 +1,30 @@
-import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/utils/supabase'
+import { useEffect, useState } from "react";
+import { clientQueries } from "@/lib/database/queries";
+import type { Seller as SellerType } from "@/types/database";
+
+export type Seller = SellerType & {
+  created_by_user: { name: string } | null;
+};
 
 export const useSellers = () => {
-  const [sellers, setSellers] = useState<any[]>([])
-  const [loading, setLoading] = useState(true)
+  const [sellers, setSellers] = useState<Seller[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchSellers = async () => {
-      const { data, error } = await supabase
-        .from('sellers')
-        .select('*')
-        .order('created_at', { ascending: false })
+      try {
+        setLoading(true);
+        const data = await clientQueries.getSellers();
+        setSellers(data as Seller[]);
+      } catch (error) {
+        console.error("Error fetching sellers:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-      if (error) console.error('Error fetching sellers:', error)
-      else setSellers(data || [])
+    fetchSellers();
+  }, []);
 
-      setLoading(false)
-    }
-
-    fetchSellers()
-  }, [])
-
-  return { sellers, loading }
-}
+  return { sellers, loading };
+};


### PR DESCRIPTION
I have introduced a new page for creating deals at `/app/deals/new`. The page includes a form with fields for seller, buyer, investor (optional), and status.

- The dropdowns for sellers, buyers, and investors are populated with data fetched from the Supabase database.
- New hooks `useBuyers` and `useInvestors` have been created to fetch data, and the existing `useSellers` hook has been updated to use a consistent data fetching pattern with `clientQueries`.
- The form is built using `react-hook-form` for state management and `zod` for validation.
- On successful submission, a toast notification is displayed, and you are redirected to the deals page.