### PR TITLE
feat: Implement Quote Variable Config settings page

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -10,7 +10,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { SettingsIcon, Users, Building2, Calculator, Plus, Edit, Trash2, User, Mail, Shield, Save } from "lucide-react"
+import { SettingsIcon, Users, Building2, Plus, Edit, Trash2, User, Mail, Shield, Save } from "lucide-react"
 
 export default function SettingsPage() {
   const [isAddUserOpen, setIsAddUserOpen] = useState(false)
@@ -66,15 +66,6 @@ export default function SettingsPage() {
     website: "www.invictusre.com",
   }
 
-  // Sample quote variables
-  const [quoteVariables, setQuoteVariables] = useState({
-    labor_rate: 75,
-    material_markup: 15,
-    default_profit_margin: 20,
-    overhead_percentage: 10,
-    tax_rate: 8.25,
-  })
-
   const getRoleColor = (role: string) => {
     switch (role) {
       case "admin":
@@ -111,7 +102,7 @@ export default function SettingsPage() {
       </div>
 
       <Tabs defaultValue="users" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-3 bg-accent-blue">
+        <TabsList className="grid w-full grid-cols-2 bg-accent-blue">
           <TabsTrigger value="users" className="data-[state=active]:bg-white data-[state=active]:text-primary-blue">
             <Users className="w-4 h-4 mr-2" />
             Users
@@ -119,10 +110,6 @@ export default function SettingsPage() {
           <TabsTrigger value="company" className="data-[state=active]:bg-white data-[state=active]:text-primary-blue">
             <Building2 className="w-4 h-4 mr-2" />
             Company
-          </TabsTrigger>
-          <TabsTrigger value="quotes" className="data-[state=active]:bg-white data-[state=active]:text-primary-blue">
-            <Calculator className="w-4 h-4 mr-2" />
-            Quote Variables
           </TabsTrigger>
         </TabsList>
 
@@ -281,125 +268,6 @@ export default function SettingsPage() {
                 <Button className="bg-cta-blue hover:bg-primary-blue text-white">
                   <Save className="w-4 h-4 mr-2" />
                   Save Changes
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* Quote Variables Tab */}
-        <TabsContent value="quotes" className="space-y-6">
-          <h2 className="text-xl font-semibold text-gray-custom">Quote Variables</h2>
-
-          <Card className="border border-gray-200 shadow-sm">
-            <CardHeader>
-              <CardTitle className="text-gray-custom">Default Quote Settings</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="laborRate">Labor Rate ($/hour)</Label>
-                  <Input
-                    id="laborRate"
-                    type="number"
-                    value={quoteVariables.labor_rate}
-                    onChange={(e) => setQuoteVariables({ ...quoteVariables, labor_rate: Number(e.target.value) })}
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="materialMarkup">Material Markup (%)</Label>
-                  <Input
-                    id="materialMarkup"
-                    type="number"
-                    value={quoteVariables.material_markup}
-                    onChange={(e) => setQuoteVariables({ ...quoteVariables, material_markup: Number(e.target.value) })}
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="profitMargin">Default Profit Margin (%)</Label>
-                  <Input
-                    id="profitMargin"
-                    type="number"
-                    value={quoteVariables.default_profit_margin}
-                    onChange={(e) =>
-                      setQuoteVariables({ ...quoteVariables, default_profit_margin: Number(e.target.value) })
-                    }
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="overhead">Overhead Percentage (%)</Label>
-                  <Input
-                    id="overhead"
-                    type="number"
-                    value={quoteVariables.overhead_percentage}
-                    onChange={(e) =>
-                      setQuoteVariables({ ...quoteVariables, overhead_percentage: Number(e.target.value) })
-                    }
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="taxRate">Tax Rate (%)</Label>
-                  <Input
-                    id="taxRate"
-                    type="number"
-                    step="0.01"
-                    value={quoteVariables.tax_rate}
-                    onChange={(e) => setQuoteVariables({ ...quoteVariables, tax_rate: Number(e.target.value) })}
-                  />
-                </div>
-              </div>
-
-              {/* Quote Preview */}
-              <Card className="bg-accent-blue border-primary-blue mt-6">
-                <CardHeader>
-                  <CardTitle className="text-sm text-primary-blue">Quote Preview (Sample $100,000 project)</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  <div className="flex justify-between text-sm">
-                    <span>Base Cost:</span>
-                    <span>$100,000</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Labor (400 hrs × ${quoteVariables.labor_rate}):</span>
-                    <span>${(400 * quoteVariables.labor_rate).toLocaleString()}</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Material Markup ({quoteVariables.material_markup}%):</span>
-                    <span>${(100000 * (quoteVariables.material_markup / 100)).toLocaleString()}</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Overhead ({quoteVariables.overhead_percentage}%):</span>
-                    <span>${(100000 * (quoteVariables.overhead_percentage / 100)).toLocaleString()}</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Profit Margin ({quoteVariables.default_profit_margin}%):</span>
-                    <span>${(100000 * (quoteVariables.default_profit_margin / 100)).toLocaleString()}</span>
-                  </div>
-                  <hr className="border-primary-blue" />
-                  <div className="flex justify-between font-bold text-primary-blue">
-                    <span>Total Quote:</span>
-                    <span>
-                      $
-                      {(
-                        100000 +
-                        400 * quoteVariables.labor_rate +
-                        100000 * (quoteVariables.material_markup / 100) +
-                        100000 * (quoteVariables.overhead_percentage / 100) +
-                        100000 * (quoteVariables.default_profit_margin / 100)
-                      ).toLocaleString()}
-                    </span>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <div className="flex justify-end pt-4">
-                <Button className="bg-cta-blue hover:bg-primary-blue text-white">
-                  <Save className="w-4 h-4 mr-2" />
-                  Save Variables
                 </Button>
               </div>
             </CardContent>

--- a/app/settings/quotes/page.tsx
+++ b/app/settings/quotes/page.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Calculator, Save } from "lucide-react"
+import { clientQueries } from "@/lib/database/queries"
+import { useToast } from "@/hooks/use-toast"
+import type { Company, QuoteSettings } from "@/types/database"
+
+const defaultQuoteSettings: QuoteSettings = {
+  labor_rate: 75,
+  material_markup: 15,
+  default_profit_margin: 20,
+  overhead_percentage: 10,
+  tax_rate: 8.25,
+}
+
+export default function QuoteSettingsPage() {
+  const [company, setCompany] = useState<Company | null>(null)
+  const [quoteVariables, setQuoteVariables] = useState<QuoteSettings>(defaultQuoteSettings)
+  const [isLoading, setIsLoading] = useState(true)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    async function fetchCompany() {
+      try {
+        const user = await clientQueries.getCurrentUser()
+        if (user && user.company) {
+          setCompany(user.company)
+          if (user.company.quote_settings) {
+            setQuoteVariables(user.company.quote_settings)
+          }
+        }
+      } catch (error) {
+        console.error("Failed to fetch company settings:", error)
+        toast({
+          title: "Error",
+          description: "Failed to load company settings.",
+          variant: "destructive",
+        })
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchCompany()
+  }, [toast])
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target
+    setQuoteVariables((prev) => ({ ...prev, [id]: Number(value) }))
+  }
+
+  const handleSave = async () => {
+    if (!company) return
+
+    try {
+      await clientQueries.updateCompanyQuoteSettings(company.id, quoteVariables)
+      toast({
+        title: "Success",
+        description: "Quote variables have been saved.",
+      })
+    } catch (error) {
+      console.error("Failed to save quote variables:", error)
+      toast({
+        title: "Error",
+        description: "Failed to save quote variables.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  if (isLoading) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Calculator className="h-8 w-8 text-primary-blue" />
+        <h1 className="text-3xl font-bold text-gray-custom">Quote Variables</h1>
+      </div>
+
+      <Card className="border border-gray-200 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-gray-custom">Default Quote Settings</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="labor_rate">Labor Rate ($/hour)</Label>
+              <Input
+                id="labor_rate"
+                type="number"
+                value={quoteVariables.labor_rate}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="material_markup">Material Markup (%)</Label>
+              <Input
+                id="material_markup"
+                type="number"
+                value={quoteVariables.material_markup}
+                onChange={handleInputChange}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="default_profit_margin">Default Profit Margin (%)</Label>
+              <Input
+                id="default_profit_margin"
+                type="number"
+                value={quoteVariables.default_profit_margin}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="overhead_percentage">Overhead Percentage (%)</Label>
+              <Input
+                id="overhead_percentage"
+                type="number"
+                value={quoteVariables.overhead_percentage}
+                onChange={handleInputChange}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="tax_rate">Tax Rate (%)</Label>
+              <Input
+                id="tax_rate"
+                type="number"
+                step="0.01"
+                value={quoteVariables.tax_rate}
+                onChange={handleInputChange}
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end pt-4">
+            <Button className="bg-cta-blue hover:bg-primary-blue text-white" onClick={handleSave}>
+              <Save className="w-4 h-4 mr-2" />
+              Save Variables
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,12 @@
+
+> my-v0-project@0.1.0 dev
+> next dev
+
+  ▲ Next.js 14.2.16
+  - Local:        http://localhost:3000
+
+ ✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry

--- a/lib/database/queries.ts
+++ b/lib/database/queries.ts
@@ -403,6 +403,51 @@ export class ClientQueries {
     if (error) throw error
     return data
   }
+
+  async getCompany(companyId: string) {
+    if (!hasSupabaseConfig()) {
+      console.log("Mock: Getting company", companyId)
+      return {
+        id: companyId,
+        name: "Invictus Real Estate",
+        address: "123 Business Plaza, Austin, TX 78701",
+        phone: "(555) 123-4567",
+        email: "info@invictusre.com",
+        website: "www.invictusre.com",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        quote_settings: {
+          labor_rate: 75,
+          material_markup: 15,
+          default_profit_margin: 20,
+          overhead_percentage: 10,
+          tax_rate: 8.25,
+        },
+      }
+    }
+
+    const { data, error } = await this.supabase.from("companies").select("*").eq("id", companyId).single()
+
+    if (error) throw error
+    return data
+  }
+
+  async updateCompanyQuoteSettings(companyId: string, settings: any) {
+    if (!hasSupabaseConfig()) {
+      console.log("Mock: Updating company quote settings", companyId, settings)
+      return { id: companyId, quote_settings: settings }
+    }
+
+    const { data, error } = await this.supabase
+      .from("companies")
+      .update({ quote_settings: settings })
+      .eq("id", companyId)
+      .select()
+      .single()
+
+    if (error) throw error
+    return data
+  }
 }
 
 // Server-side queries

--- a/supabase/migrations/003_add_quote_settings_to_companies.sql
+++ b/supabase/migrations/003_add_quote_settings_to_companies.sql
@@ -1,0 +1,9 @@
+-- Add quote_settings column to companies table
+ALTER TABLE public.companies
+ADD COLUMN quote_settings JSONB DEFAULT '{
+  "labor_rate": 75,
+  "material_markup": 15,
+  "default_profit_margin": 20,
+  "overhead_percentage": 10,
+  "tax_rate": 8.25
+}'::jsonb;

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,3 +1,11 @@
+export type QuoteSettings = {
+  labor_rate: number
+  material_markup: number
+  default_profit_margin: number
+  overhead_percentage: number
+  tax_rate: number
+}
+
 export interface Database {
   public: {
     Tables: {
@@ -6,16 +14,19 @@ export interface Database {
           id: string
           name: string
           created_at: string
+          quote_settings: QuoteSettings
         }
         Insert: {
           id?: string
           name: string
           created_at?: string
+          quote_settings?: QuoteSettings
         }
         Update: {
           id?: string
           name?: string
           created_at?: string
+          quote_settings?: QuoteSettings
         }
       }
       users: {


### PR DESCRIPTION
This commit introduces a new settings page for managing company-specific quote variables. The key changes include:

- A new database migration to add a `quote_settings` JSONB column to the `companies` table.
- Updated database types to include the new `quote_settings`.
- Extended `ClientQueries` with methods to fetch and update company settings.
- Created a new page at `app/settings/quotes/page.tsx` for editing quote variables.
- Removed the redundant 'Quote Variables' tab from the main settings page to avoid duplication.